### PR TITLE
move Serialize / Deserialize to serde with derive feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ dependencies = [
  "parking_lot",
  "scylla",
  "serde",
- "serde_derive",
  "simple_wal",
  "tokio",
  "tokio-postgres",
@@ -876,6 +875,9 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,12 @@ repository = "https://github.com/Rustixir/darkbird"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio          = {version = "1.17.0", features = ["rt-multi-thread", "time", "macros", "sync"]} 
+tokio          = { version = "1.17.0", features = ["rt-multi-thread", "time", "macros", "sync"]} 
 scylla         = "0.4.7"
 tokio-postgres = "0.7.6"
 simple_wal     = "0.3.0"
 dashmap        = "5.2.0"
-serde_derive   = "1.0.136"
-serde          = "1.0.136"
+serde          = { verseion = "1.0.136", features = ["derive"] }
 bincode        = "1.3.3"
 async-trait    = "0.1.56" 
 parking_lot    = "0.12.1"

--- a/src/darkbird/storage.rs
+++ b/src/darkbird/storage.rs
@@ -1,5 +1,4 @@
-use serde::{de::DeserializeOwned, Serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
 use std::hash::Hash;
 use tokio::sync::mpsc::Sender;
 


### PR DESCRIPTION
Bug fix traceable throughout project | https://serde.rs/derive.html
 
 ```
 --> C:\...\darkbird-6.1.0\src\darkbird\storage.rs:2:33
  |
1 | use serde::{de::DeserializeOwned, Serialize};
  |                                   --------- previous import of the macro `Serialize` here
2 | use serde_derive::{Deserialize, Serialize};
  |                                 ^^^^^^^^^ `Serialize` reimported here
  |
  = note: `Serialize` must be defined only once in the macro namespace of this module
  ```